### PR TITLE
Shirley refresh for daily stack feature

### DIFF
--- a/metau-capstone.xcworkspace/xcuserdata/shirleyzzhu.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/metau-capstone.xcworkspace/xcuserdata/shirleyzzhu.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -3,22 +3,4 @@
    uuid = "54AC4DCD-CC84-4485-B7FA-0BC1B9277227"
    type = "0"
    version = "2.0">
-   <Breakpoints>
-      <BreakpointProxy
-         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
-         <BreakpointContent
-            uuid = "12EF6AA1-BA7A-4C7C-95F6-5A411DB0D73B"
-            shouldBeEnabled = "Yes"
-            ignoreCount = "0"
-            continueAfterRunningActions = "No"
-            filePath = "metau-capstone/StudyViewController.m"
-            startingColumnNumber = "9223372036854775807"
-            endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "95"
-            endingLineNumber = "95"
-            landmarkName = "-viewDidLoad"
-            landmarkType = "7">
-         </BreakpointContent>
-      </BreakpointProxy>
-   </Breakpoints>
 </Bucket>

--- a/metau-capstone.xcworkspace/xcuserdata/shirleyzzhu.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/metau-capstone.xcworkspace/xcuserdata/shirleyzzhu.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -3,4 +3,22 @@
    uuid = "54AC4DCD-CC84-4485-B7FA-0BC1B9277227"
    type = "0"
    version = "2.0">
+   <Breakpoints>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "12EF6AA1-BA7A-4C7C-95F6-5A411DB0D73B"
+            shouldBeEnabled = "Yes"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "metau-capstone/StudyViewController.m"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "95"
+            endingLineNumber = "95"
+            landmarkName = "-viewDidLoad"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
+   </Breakpoints>
 </Bucket>

--- a/metau-capstone/StudyViewController.m
+++ b/metau-capstone/StudyViewController.m
@@ -96,12 +96,8 @@
                 [queryForDay getObjectInBackgroundWithId:user.objectId
                                              block:^(PFObject *userObject, NSError *error) {
                     if (userObject) {
-                        // Increment day counter for the user
-                        [userObject incrementKey:@"userDay"];
-                        
                         self.dayNum = userObject[@"userDay"];
                         [userObject saveInBackground];
-                        
                         NSLog(@"day: %@", self.dayNum);
                         // Query for today's level numbers
                         PFQuery *queryForLevels = [PFQuery queryWithClassName:@"Schedule"];
@@ -112,6 +108,7 @@
                             for (Schedule *object in objects) {
                                 NSArray *arrayOfLevels = object.arrayOfLevels;
                                 NSString *constraintForCards = @"(userID = %@) AND ";
+//                                NSString *constraintForCards = [NSString stringWithFormat:@"(userID = %@) AND ", user.objectId];
                                 // Construct string containing the level numbers
                                 for (int i = 0; i < arrayOfLevels.count; i++) {
                                     if (i == 0) {
@@ -124,6 +121,7 @@
                                 }
 
                                 // Construct Query for Flashcards
+                                NSLog(@"%@", constraintForCards);
                                 NSPredicate *predicate = [NSPredicate predicateWithFormat:constraintForCards, user.objectId];
                                 PFQuery *query = [PFQuery queryWithClassName:@"Flashcard" predicate:predicate];
                                 
@@ -187,7 +185,6 @@
         NSLog(@"reached end of stack");
         [self endScreen];
         
-        // Update lastFinished date
         NSLocale* currentLocale = [NSLocale currentLocale];
         NSDate *currentDate = [NSDate date];
         [currentDate descriptionWithLocale:currentLocale];
@@ -201,8 +198,12 @@
         [query getObjectInBackgroundWithId:user.objectId
                                      block:^(PFObject *userObject, NSError *error) {
             if (userObject) {
+                // Update lastFinished date
                 userObject[@"prevFinishedDate"] = dateString;
                 [userObject saveInBackground];
+                
+                // Increment day counter for the user
+                [userObject incrementKey:@"userDay"];
             }
             else {
                 NSLog(@"no user");

--- a/metau-capstone/StudyViewController.m
+++ b/metau-capstone/StudyViewController.m
@@ -91,13 +91,14 @@
                 [self endScreen];
             }
             else {
-                // TODO: Increment day counter for the user
-                
                 // Query for today's number for the current user
                 PFQuery *queryForDay = [PFUser query];
                 [queryForDay getObjectInBackgroundWithId:user.objectId
                                              block:^(PFObject *userObject, NSError *error) {
                     if (userObject) {
+                        // Increment day counter for the user
+                        [userObject incrementKey:@"userDay"];
+                        
                         self.dayNum = userObject[@"userDay"];
                         NSLog(@"day: %@", self.dayNum);
                         // Query for today's level numbers

--- a/metau-capstone/StudyViewController.m
+++ b/metau-capstone/StudyViewController.m
@@ -100,6 +100,8 @@
                         [userObject incrementKey:@"userDay"];
                         
                         self.dayNum = userObject[@"userDay"];
+                        [userObject saveInBackground];
+                        
                         NSLog(@"day: %@", self.dayNum);
                         // Query for today's level numbers
                         PFQuery *queryForLevels = [PFQuery queryWithClassName:@"Schedule"];

--- a/metau-capstone/StudyViewController.m
+++ b/metau-capstone/StudyViewController.m
@@ -10,6 +10,7 @@
 #import "SceneDelegate.h"
 #import "LoginViewController.h"
 #import "Flashcard.h"
+#import "Schedule.h"
 
 @interface StudyViewController ()
 @property (nonatomic, strong) CALayer *front;
@@ -41,6 +42,26 @@
         if (userObject) {
             self.dayNum = userObject[@"userDay"];
             NSLog(@"day: %@", self.dayNum);
+            // Query for today's level numbers
+            PFQuery *queryForLevels = [PFQuery queryWithClassName:@"Schedule"];
+            [queryForLevels whereKey:@"dayNum" equalTo:self.dayNum];
+            
+            [queryForLevels findObjectsInBackgroundWithBlock:^(NSArray *objects, NSError *error) {
+              if (!error) {
+                for (Schedule *object in objects) {
+                    NSArray *arrayOfLevels = object.arrayOfLevels;
+                    // Construct string containing the level numbers
+                    for (NSNumber *num in arrayOfLevels) {
+                        NSLog(@"%@", num);
+                    }
+                }
+              } else {
+                // Log details of the failure
+                NSLog(@"Error: %@ %@", error, [error userInfo]);
+              }
+            }];
+
+            
             // Construct Query for Flashcards
             NSPredicate *predicate = [NSPredicate predicateWithFormat:@"(userID = %@) AND ((levelNum = 1) OR (levelNum = 2))", user.objectId];
             PFQuery *query = [PFQuery queryWithClassName:@"Flashcard" predicate:predicate];

--- a/metau-capstone/StudyViewController.m
+++ b/metau-capstone/StudyViewController.m
@@ -50,6 +50,10 @@
         if (userObject) {
             if ([todayDate isEqualToString:userObject[@"prevFinishedDate"]]) {
                 NSLog(@"yay!");
+                // show the end screen
+            }
+            else {
+                // Increment day counter for the user
             }
         }
         else {
@@ -179,16 +183,7 @@
         self.congratsLabel.hidden = NO;
         NSLog(@"reached end of stack");
         
-        //BACK SIDE
-        // add text label to the flashcard
-        [self.backText setString:@"Come back tomorrow for your new stack :-)"];
-        self.back.transform = CATransform3DMakeRotation(M_PI, 0, -1, 0);
-        [self.view.layer addSublayer:self.back];
-        
-        // FRONT SIDE
-        // add text label to the flashcard
-        [self.frontText setString:@"You finished studying today's cards!"];
-        [self.view.layer addSublayer:self.front];
+        [self endScreen];
         
         // Update lastFinished date
         NSLocale* currentLocale = [NSLocale currentLocale];
@@ -212,6 +207,19 @@
             }
         }];
     }
+}
+
+- (void) endScreen {
+    // BACK SIDE
+    // add text label to the flashcard
+    [self.backText setString:@"Come back tomorrow for your new stack :-)"];
+    self.back.transform = CATransform3DMakeRotation(M_PI, 0, -1, 0);
+    [self.view.layer addSublayer:self.back];
+    
+    // FRONT SIDE
+    // add text label to the flashcard
+    [self.frontText setString:@"You finished studying today's cards!"];
+    [self.view.layer addSublayer:self.front];
 }
 
 - (IBAction)didTapRight:(UIButton *)sender {

--- a/metau-capstone/StudyViewController.m
+++ b/metau-capstone/StudyViewController.m
@@ -86,7 +86,6 @@
                                  block:^(PFObject *userObject, NSError *error) {
         if (userObject) {
             if ([todayDate isEqualToString:userObject[@"prevFinishedDate"]]) {
-                NSLog(@"yay!");
                 // show the end screen
                 [self endScreen];
             }
@@ -108,7 +107,6 @@
                             for (Schedule *object in objects) {
                                 NSArray *arrayOfLevels = object.arrayOfLevels;
                                 NSString *constraintForCards = @"(userID = %@) AND ";
-//                                NSString *constraintForCards = [NSString stringWithFormat:@"(userID = %@) AND ", user.objectId];
                                 // Construct string containing the level numbers
                                 for (int i = 0; i < arrayOfLevels.count; i++) {
                                     if (i == 0) {
@@ -121,7 +119,6 @@
                                 }
 
                                 // Construct Query for Flashcards
-                                NSLog(@"%@", constraintForCards);
                                 NSPredicate *predicate = [NSPredicate predicateWithFormat:constraintForCards, user.objectId];
                                 PFQuery *query = [PFQuery queryWithClassName:@"Flashcard" predicate:predicate];
                                 

--- a/metau-capstone/StudyViewController.m
+++ b/metau-capstone/StudyViewController.m
@@ -35,6 +35,28 @@
     [super viewDidLoad];
     PFUser *user = [PFUser currentUser];
     
+    // Check if it is a new day
+    NSLocale* currentLocale = [NSLocale currentLocale];
+    NSDate *currentDate = [NSDate date];
+    [currentDate descriptionWithLocale:currentLocale];
+    NSDateFormatter *dateFormatter=[[NSDateFormatter alloc] init];
+    [dateFormatter setDateFormat:@"yyyy-MM-dd"];
+    NSString *todayDate = [dateFormatter stringFromDate:currentDate];
+    
+    // Query for prevFinishedDate
+    PFQuery *queryForPrevDate = [PFUser query];
+    [queryForPrevDate getObjectInBackgroundWithId:user.objectId
+                                 block:^(PFObject *userObject, NSError *error) {
+        if (userObject) {
+            if ([todayDate isEqualToString:userObject[@"prevFinishedDate"]]) {
+                NSLog(@"yay!");
+            }
+        }
+        else {
+            NSLog(@"no user");
+        }
+    }];
+    
     // Query for today's number for the current user
     PFQuery *queryForDay = [PFUser query];
     [queryForDay getObjectInBackgroundWithId:user.objectId
@@ -61,12 +83,12 @@
                             
                         }
                     }
-                    NSLog(@"%@", constraintForCards);
+
                     // Construct Query for Flashcards
                     NSPredicate *predicate = [NSPredicate predicateWithFormat:constraintForCards, user.objectId];
                     PFQuery *query = [PFQuery queryWithClassName:@"Flashcard" predicate:predicate];
                     
-                    // Fetch data asynchronously
+                    // Fetch data for cards asynchronously
                     [query findObjectsInBackgroundWithBlock:^(NSArray *cards, NSError *error) {
                         if (cards != nil) {
                             self.arrayOfCards = cards;

--- a/metau-capstone/StudyViewController.m
+++ b/metau-capstone/StudyViewController.m
@@ -128,6 +128,28 @@
         // add text label to the flashcard
         [self.frontText setString:@"You finished studying today's cards!"];
         [self.view.layer addSublayer:self.front];
+        
+        // Update lastFinished date
+        NSLocale* currentLocale = [NSLocale currentLocale];
+        NSDate *currentDate = [NSDate date];
+        [currentDate descriptionWithLocale:currentLocale];
+        NSDateFormatter *dateFormatter=[[NSDateFormatter alloc] init];
+        [dateFormatter setDateFormat:@"yyyy-MM-dd"];
+        NSString *dateString = [dateFormatter stringFromDate:currentDate];
+        
+        PFUser *user = [PFUser currentUser];
+        PFQuery *query = [PFUser query];
+        // Retrieve the object by id
+        [query getObjectInBackgroundWithId:user.objectId
+                                     block:^(PFObject *userObject, NSError *error) {
+            if (userObject) {
+                userObject[@"prevFinishedDate"] = dateString;
+                [userObject saveInBackground];
+            }
+            else {
+                NSLog(@"no user");
+            }
+        }];
     }
 }
 

--- a/metau-capstone/StudyViewController.m
+++ b/metau-capstone/StudyViewController.m
@@ -57,12 +57,13 @@
                             constraintForCards = [constraintForCards stringByAppendingFormat:@"(levelNum = %@)", arrayOfLevels[i]];
                         }
                         else {
-                            constraintForCards = [constraintForCards stringByAppendingFormat:@" OR (levelNum = %@)", arrayOfLevels[i]];                        }
+                            constraintForCards = [constraintForCards stringByAppendingFormat:@" OR (levelNum = %@)", arrayOfLevels[i]];
+                            
+                        }
                     }
                     NSLog(@"%@", constraintForCards);
-                    NSString *test = @"(userID = %@) AND ((levelNum = 1) OR (levelNum = 2))";
                     // Construct Query for Flashcards
-                    NSPredicate *predicate = [NSPredicate predicateWithFormat:test, user.objectId];
+                    NSPredicate *predicate = [NSPredicate predicateWithFormat:constraintForCards, user.objectId];
                     PFQuery *query = [PFQuery queryWithClassName:@"Flashcard" predicate:predicate];
                     
                     // Fetch data asynchronously
@@ -86,7 +87,6 @@
             NSLog(@"no user");
         }
     }];
-    NSLog(@"outside - day: %@", self.dayNum);
     
     // Instantiate flashcard sides
     // BACK SIDE


### PR DESCRIPTION
- query for the prevFinishedDate
- if the prevFinishedDate is the same as the current date, then display the end screen
- if the prevFinishedDate is different from the current date, then query for the user's day number
- query for which card levels correspond to the user's day number
- query for the cards that correspond with the card levels

Demos:
In the first video, the app displays the correct cards for the user to review. When the user gets through the study stack, the day number increments and the prevFinishedDate is updated.

https://user-images.githubusercontent.com/44847817/178847575-727e5470-5f96-4153-8c17-3436d7354a8f.mov

In the second video, the end screen is displayed because the current date matches the prevFinishedDate.

https://user-images.githubusercontent.com/44847817/178847617-9049b981-863d-473f-9273-05c9c4c5938a.mov


