### PR TITLE
Shirley schedule screen

### DIFF
--- a/metau-capstone.xcodeproj/project.pbxproj
+++ b/metau-capstone.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		2F86790F131E6D1D53AFFCA1 /* Pods_metau_capstone_metau_capstoneUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E46AD704B113431C11BBAA69 /* Pods_metau_capstone_metau_capstoneUITests.framework */; };
 		850905AF288088D300AD9B8F /* Utilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 850905AE288088D300AD9B8F /* Utilities.m */; };
+		850905B52881D47B00AD9B8F /* ScheduleCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 850905B42881D47B00AD9B8F /* ScheduleCell.m */; };
 		858CB535286FA73C005805D1 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 858CB534286FA73C005805D1 /* AppDelegate.m */; };
 		858CB538286FA73C005805D1 /* SceneDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 858CB537286FA73C005805D1 /* SceneDelegate.m */; };
 		858CB53B286FA73C005805D1 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 858CB53A286FA73C005805D1 /* ViewController.m */; };
@@ -55,6 +56,8 @@
 		719596D47D5CE237532F3045 /* Pods-metau-capstone-metau-capstoneUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-metau-capstone-metau-capstoneUITests.debug.xcconfig"; path = "Target Support Files/Pods-metau-capstone-metau-capstoneUITests/Pods-metau-capstone-metau-capstoneUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		850905AD288088D300AD9B8F /* Utilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Utilities.h; sourceTree = "<group>"; };
 		850905AE288088D300AD9B8F /* Utilities.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Utilities.m; sourceTree = "<group>"; };
+		850905B32881D47B00AD9B8F /* ScheduleCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ScheduleCell.h; sourceTree = "<group>"; };
+		850905B42881D47B00AD9B8F /* ScheduleCell.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ScheduleCell.m; sourceTree = "<group>"; };
 		858CB530286FA73C005805D1 /* metau-capstone.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "metau-capstone.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		858CB533286FA73C005805D1 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		858CB534286FA73C005805D1 /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
@@ -149,6 +152,8 @@
 				858CB539286FA73C005805D1 /* ViewController.h */,
 				858CB53A286FA73C005805D1 /* ViewController.m */,
 				858CB53C286FA73C005805D1 /* Main.storyboard */,
+				850905B32881D47B00AD9B8F /* ScheduleCell.h */,
+				850905B42881D47B00AD9B8F /* ScheduleCell.m */,
 				85CC1A8828765C8100155F8A /* CreateViewController.h */,
 				85CC1A8928765C8100155F8A /* CreateViewController.m */,
 				85CC1A8B28765C9000155F8A /* ScheduleViewController.h */,
@@ -451,6 +456,7 @@
 			files = (
 				85CC1A96287E14F300155F8A /* Schedule.m in Sources */,
 				858CB53B286FA73C005805D1 /* ViewController.m in Sources */,
+				850905B52881D47B00AD9B8F /* ScheduleCell.m in Sources */,
 				858CB535286FA73C005805D1 /* AppDelegate.m in Sources */,
 				858CB5762876346C005805D1 /* StudyViewController.m in Sources */,
 				85CC1A8A28765C8100155F8A /* CreateViewController.m in Sources */,

--- a/metau-capstone/Base.lproj/Main.storyboard
+++ b/metau-capstone/Base.lproj/Main.storyboard
@@ -313,15 +313,15 @@
                                             <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Day" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="y1n-xX-ATs">
-                                                    <rect key="frame" x="8" y="4" width="30" height="21"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Levels" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nFr-C9-7p2">
+                                                    <rect key="frame" x="8" y="33" width="112" height="84"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Levels" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nFr-C9-7p2">
-                                                    <rect key="frame" x="8" y="33" width="48" height="21"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Day" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="y1n-xX-ATs">
+                                                    <rect key="frame" x="17" y="8" width="30" height="21"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -331,7 +331,7 @@
                                         </collectionViewCellContentView>
                                         <connections>
                                             <outlet property="dayNum" destination="y1n-xX-ATs" id="SCV-gl-cZj"/>
-                                            <outlet property="levelsLabel" destination="zC0-x9-kzx" id="gPh-pH-pBb"/>
+                                            <outlet property="levelsLabel" destination="nFr-C9-7p2" id="3HN-oo-mdt"/>
                                         </connections>
                                     </collectionViewCell>
                                 </cells>
@@ -359,7 +359,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="VRn-kW-tEu" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="3521.739130434783" y="2580.8035714285711"/>
+            <point key="canvasLocation" x="3521.739130434783" y="2580.1339285714284"/>
         </scene>
     </scenes>
     <resources>

--- a/metau-capstone/Base.lproj/Main.storyboard
+++ b/metau-capstone/Base.lproj/Main.storyboard
@@ -296,9 +296,8 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="chG-T4-nRf">
-                                <rect key="frame" x="0.0" y="103" width="414" height="656"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="chG-T4-nRf">
+                                <rect key="frame" x="0.0" y="56" width="414" height="757"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="Uiv-bv-spY">
                                     <size key="itemSize" width="128" height="128"/>
@@ -332,6 +331,12 @@
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="KN0-5C-YJf"/>
                         <color key="backgroundColor" red="0.67132152314796445" green="0.83426602015526541" blue="0.86078917980194092" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                        <constraints>
+                            <constraint firstItem="chG-T4-nRf" firstAttribute="leading" secondItem="KN0-5C-YJf" secondAttribute="leading" id="3Fh-0g-dJL"/>
+                            <constraint firstItem="chG-T4-nRf" firstAttribute="trailing" secondItem="KN0-5C-YJf" secondAttribute="trailing" id="BIN-EE-0nC"/>
+                            <constraint firstItem="KN0-5C-YJf" firstAttribute="bottom" secondItem="chG-T4-nRf" secondAttribute="bottom" id="nKu-2I-khS"/>
+                            <constraint firstItem="chG-T4-nRf" firstAttribute="top" secondItem="KN0-5C-YJf" secondAttribute="top" id="wzC-Ju-51b"/>
+                        </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="Schedule" id="71V-YN-awj">
                         <barButtonItem key="leftBarButtonItem" title="Item" image="rectangle.portrait.and.arrow.right" catalog="system" id="dUN-J2-bXq">

--- a/metau-capstone/Base.lproj/Main.storyboard
+++ b/metau-capstone/Base.lproj/Main.storyboard
@@ -5,6 +5,7 @@
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="collection view cell content view" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -294,6 +295,41 @@
                     <view key="view" contentMode="scaleToFill" id="9TQ-zA-9RO">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="chG-T4-nRf">
+                                <rect key="frame" x="0.0" y="103" width="414" height="656"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="Uiv-bv-spY">
+                                    <size key="itemSize" width="128" height="128"/>
+                                    <size key="headerReferenceSize" width="0.0" height="0.0"/>
+                                    <size key="footerReferenceSize" width="0.0" height="0.0"/>
+                                    <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
+                                </collectionViewFlowLayout>
+                                <cells>
+                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="ScheduleCollectionCell" id="isZ-6f-N6b" customClass="ScheduleCell">
+                                        <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="zC0-x9-kzx">
+                                            <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="y1n-xX-ATs">
+                                                    <rect key="frame" x="8" y="8" width="42" height="21"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </collectionViewCellContentView>
+                                        <connections>
+                                            <outlet property="dayNum" destination="y1n-xX-ATs" id="SCV-gl-cZj"/>
+                                        </connections>
+                                    </collectionViewCell>
+                                </cells>
+                            </collectionView>
+                        </subviews>
                         <viewLayoutGuide key="safeArea" id="KN0-5C-YJf"/>
                         <color key="backgroundColor" red="0.67132152314796445" green="0.83426602015526541" blue="0.86078917980194092" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                     </view>
@@ -304,10 +340,13 @@
                             </connections>
                         </barButtonItem>
                     </navigationItem>
+                    <connections>
+                        <outlet property="scheduleCollection" destination="chG-T4-nRf" id="i4b-9X-Hd4"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="VRn-kW-tEu" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="3522" y="2581"/>
+            <point key="canvasLocation" x="3521.739130434783" y="2580.8035714285711"/>
         </scene>
     </scenes>
     <resources>

--- a/metau-capstone/Base.lproj/Main.storyboard
+++ b/metau-capstone/Base.lproj/Main.storyboard
@@ -321,7 +321,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Day" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="y1n-xX-ATs">
-                                                    <rect key="frame" x="17" y="8" width="30" height="21"/>
+                                                    <rect key="frame" x="8" y="8" width="30" height="21"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>

--- a/metau-capstone/Base.lproj/Main.storyboard
+++ b/metau-capstone/Base.lproj/Main.storyboard
@@ -297,7 +297,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="chG-T4-nRf">
-                                <rect key="frame" x="0.0" y="56" width="414" height="757"/>
+                                <rect key="frame" x="10" y="56" width="394" height="757"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="Uiv-bv-spY">
                                     <size key="itemSize" width="128" height="128"/>
@@ -332,8 +332,8 @@
                         <viewLayoutGuide key="safeArea" id="KN0-5C-YJf"/>
                         <color key="backgroundColor" red="0.67132152314796445" green="0.83426602015526541" blue="0.86078917980194092" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                         <constraints>
-                            <constraint firstItem="chG-T4-nRf" firstAttribute="leading" secondItem="KN0-5C-YJf" secondAttribute="leading" id="3Fh-0g-dJL"/>
-                            <constraint firstItem="chG-T4-nRf" firstAttribute="trailing" secondItem="KN0-5C-YJf" secondAttribute="trailing" id="BIN-EE-0nC"/>
+                            <constraint firstItem="chG-T4-nRf" firstAttribute="leading" secondItem="KN0-5C-YJf" secondAttribute="leading" constant="10" id="3Fh-0g-dJL"/>
+                            <constraint firstItem="chG-T4-nRf" firstAttribute="trailing" secondItem="KN0-5C-YJf" secondAttribute="trailing" constant="-10" id="BIN-EE-0nC"/>
                             <constraint firstItem="KN0-5C-YJf" firstAttribute="bottom" secondItem="chG-T4-nRf" secondAttribute="bottom" id="nKu-2I-khS"/>
                             <constraint firstItem="chG-T4-nRf" firstAttribute="top" secondItem="KN0-5C-YJf" secondAttribute="top" id="wzC-Ju-51b"/>
                         </constraints>

--- a/metau-capstone/Base.lproj/Main.storyboard
+++ b/metau-capstone/Base.lproj/Main.storyboard
@@ -313,8 +313,15 @@
                                             <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="y1n-xX-ATs">
-                                                    <rect key="frame" x="8" y="8" width="42" height="21"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Day" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="y1n-xX-ATs">
+                                                    <rect key="frame" x="8" y="4" width="30" height="21"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Levels" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nFr-C9-7p2">
+                                                    <rect key="frame" x="8" y="33" width="48" height="21"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -324,6 +331,7 @@
                                         </collectionViewCellContentView>
                                         <connections>
                                             <outlet property="dayNum" destination="y1n-xX-ATs" id="SCV-gl-cZj"/>
+                                            <outlet property="levelsLabel" destination="zC0-x9-kzx" id="gPh-pH-pBb"/>
                                         </connections>
                                     </collectionViewCell>
                                 </cells>

--- a/metau-capstone/Base.lproj/Main.storyboard
+++ b/metau-capstone/Base.lproj/Main.storyboard
@@ -298,7 +298,7 @@
                         <subviews>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="chG-T4-nRf">
                                 <rect key="frame" x="10" y="56" width="394" height="757"/>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <color key="backgroundColor" red="0.67132152310000004" green="0.83426602019999996" blue="0.86078917980000003" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="Uiv-bv-spY">
                                     <size key="itemSize" width="128" height="128"/>
                                     <size key="headerReferenceSize" width="0.0" height="0.0"/>

--- a/metau-capstone/ScheduleCell.h
+++ b/metau-capstone/ScheduleCell.h
@@ -1,0 +1,17 @@
+//
+//  ScheduleCell.h
+//  metau-capstone
+//
+//  Created by Shirley Zhu on 7/15/22.
+//
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ScheduleCell : UICollectionViewCell
+@property (weak, nonatomic) IBOutlet UILabel *dayNum;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/metau-capstone/ScheduleCell.h
+++ b/metau-capstone/ScheduleCell.h
@@ -11,7 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ScheduleCell : UICollectionViewCell
 @property (weak, nonatomic) IBOutlet UILabel *dayNum;
-@property (weak, nonatomic) IBOutlet UIView *levelsLabel;
+@property (weak, nonatomic) IBOutlet UILabel *levelsLabel;
 
 
 @end

--- a/metau-capstone/ScheduleCell.h
+++ b/metau-capstone/ScheduleCell.h
@@ -11,6 +11,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ScheduleCell : UICollectionViewCell
 @property (weak, nonatomic) IBOutlet UILabel *dayNum;
+@property (weak, nonatomic) IBOutlet UIView *levelsLabel;
+
 
 @end
 

--- a/metau-capstone/ScheduleCell.m
+++ b/metau-capstone/ScheduleCell.m
@@ -1,0 +1,12 @@
+//
+//  ScheduleCell.m
+//  metau-capstone
+//
+//  Created by Shirley Zhu on 7/15/22.
+//
+
+#import "ScheduleCell.h"
+
+@implementation ScheduleCell
+
+@end

--- a/metau-capstone/ScheduleViewController.m
+++ b/metau-capstone/ScheduleViewController.m
@@ -16,7 +16,6 @@
 
 @interface ScheduleViewController () <UICollectionViewDataSource, UICollectionViewDelegate>
 @property (weak, nonatomic) IBOutlet UICollectionView *scheduleCollection;
-
 @end
 
 @implementation ScheduleViewController
@@ -25,9 +24,6 @@
     [super viewDidLoad];
     self.scheduleCollection.dataSource = self;
     self.scheduleCollection.delegate = self;
-//    UILabel *fromLabel = [[UILabel alloc]initWithFrame:CGRectMake(10, 0, 100, 100)];
-//    fromLabel.text = @"hi";
-//    [self.scheduleCollection addSubview:fromLabel];
 }
 
 - (IBAction)didTapLogout:(id)sender {
@@ -52,6 +48,23 @@
     cell.layer.borderColor = [UIColor blackColor].CGColor;
     cell.layer.borderWidth = 1;
     
+    // Query for user's day
+    PFQuery *queryForDay = [PFUser query];
+    PFUser *const user = [PFUser currentUser];
+    [queryForDay getObjectInBackgroundWithId:user.objectId block:^(PFObject * _Nullable object, NSError * _Nullable error) {
+        if (!error) {
+            // Highlight current day
+            if ([object[@"userDay"] isEqualToNumber:@(indexPath.row+1)]) {
+                cell.dayNum.backgroundColor = [UIColor yellowColor];
+                NSLog(@"%@", object[@"userDay"]);
+                NSLog(@"%@", @(indexPath.row+1));
+            }
+            else {
+                cell.dayNum.backgroundColor = [UIColor clearColor];
+            }
+        }
+    }];
+    
     //Query for the day's levels
     PFQuery *queryForLevels = [PFQuery queryWithClassName:@"Schedule"];
     [queryForLevels whereKey:@"dayNum" equalTo:@(indexPath.row+1)];
@@ -68,7 +81,6 @@
                         levelsText = [levelsText stringByAppendingFormat:@"\rLevel %@", arrayOfLevels[i]];
                     }
                 }
-                NSLog(@"%@", levelsText);
                 cell.levelsLabel.text = levelsText;
             }
         }

--- a/metau-capstone/ScheduleViewController.m
+++ b/metau-capstone/ScheduleViewController.m
@@ -27,14 +27,14 @@
     self.scheduleCollection.delegate = self;
 }
 
-- (void)viewDidLayoutSubviews {
-   [super viewDidLayoutSubviews];
-
-    self.flowLayout.scrollDirection = UICollectionViewScrollDirectionHorizontal;
-    self.flowLayout.minimumLineSpacing = 0;
-    self.flowLayout.minimumInteritemSpacing = 0;
-    self.flowLayout.sectionInset = UIEdgeInsetsMake(0, 0, 0, 10);
-}
+//- (void)viewDidLayoutSubviews {
+//   [super viewDidLayoutSubviews];
+//
+//    self.flowLayout.scrollDirection = UICollectionViewScrollDirectionHorizontal;
+//    self.flowLayout.minimumLineSpacing = 0;
+//    self.flowLayout.minimumInteritemSpacing = 0;
+//    self.flowLayout.sectionInset = UIEdgeInsetsMake(0, 0, 0, 10);
+//}
 
 
 - (IBAction)didTapLogout:(id)sender {
@@ -70,7 +70,22 @@
     int numberOfCellsPerRow = 4;
     
     int dimensions = (CGFloat)(totalwidth / (numberOfCellsPerRow + 1));
-    return CGSizeMake(dimensions, dimensions*1.2);
+    return CGSizeMake(dimensions*1.2, dimensions*1.5);
+}
+
+- (CGFloat)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout*)collectionViewLayout minimumInteritemSpacingForSectionAtIndex:(NSInteger)section {
+    return 2.0;
+}
+
+- (CGFloat)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout*)collectionViewLayout minimumLineSpacingForSectionAtIndex:(NSInteger)section {
+    return 15.0;
+}
+
+// Layout: Set Edges
+- (UIEdgeInsets)collectionView:
+(UICollectionView *)collectionView layout:(UICollectionViewLayout*)collectionViewLayout insetForSectionAtIndex:(NSInteger)section {
+   // return UIEdgeInsetsMake(0,8,0,8);  // top, left, bottom, right
+    return UIEdgeInsetsMake(0,0,0,0);  // top, left, bottom, right
 }
 
 @end

--- a/metau-capstone/ScheduleViewController.m
+++ b/metau-capstone/ScheduleViewController.m
@@ -11,8 +11,10 @@
 #import "LoginViewController.h"
 #import "Schedule.h"
 #import "Utilities.h"
+#import "ScheduleCell.h"
 
-@interface ScheduleViewController ()
+@interface ScheduleViewController () <UICollectionViewDataSource>
+@property (weak, nonatomic) IBOutlet UICollectionView *scheduleCollection;
 
 @end
 
@@ -20,6 +22,7 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
+    self.scheduleCollection.dataSource = self;
 
 }
 
@@ -38,5 +41,15 @@
     // Pass the selected object to the new view controller.
 }
 */
+
+- (nonnull __kindof UICollectionViewCell *)collectionView:(nonnull UICollectionView *)collectionView cellForItemAtIndexPath:(nonnull NSIndexPath *)indexPath {
+    ScheduleCell *cell = [self.scheduleCollection dequeueReusableCellWithReuseIdentifier:@"ScheduleCollectionCell" forIndexPath:indexPath];
+    cell.dayNum.text = [NSString stringWithFormat:@"%ld", indexPath.row];
+    return cell;
+}
+
+- (NSInteger)collectionView:(nonnull UICollectionView *)collectionView numberOfItemsInSection:(NSInteger)section {
+    return 10;
+}
 
 @end

--- a/metau-capstone/ScheduleViewController.m
+++ b/metau-capstone/ScheduleViewController.m
@@ -43,6 +43,7 @@
 */
 
 - (nonnull __kindof UICollectionViewCell *)collectionView:(nonnull UICollectionView *)collectionView cellForItemAtIndexPath:(nonnull NSIndexPath *)indexPath {
+    NSNumber *cellNum = @(indexPath.row+1);
     ScheduleCell *cell = [self.scheduleCollection dequeueReusableCellWithReuseIdentifier:@"ScheduleCollectionCell" forIndexPath:indexPath];
     cell.dayNum.text = [NSString stringWithFormat:@"%ld", indexPath.row+1];
     cell.layer.borderColor = [UIColor blackColor].CGColor;
@@ -54,12 +55,9 @@
     [queryForDay getObjectInBackgroundWithId:user.objectId block:^(PFObject * _Nullable object, NSError * _Nullable error) {
         if (!error) {
             // Highlight current day
-            if ([object[@"userDay"] isEqualToNumber:@(indexPath.row+1)]) {
+            if ([object[@"userDay"] isEqualToNumber:cellNum]) {
                 cell.dayNum.backgroundColor = [UIColor yellowColor];
-                NSLog(@"%@", object[@"userDay"]);
-                NSLog(@"%@", @(indexPath.row+1));
-            }
-            else {
+            } else {
                 cell.dayNum.backgroundColor = [UIColor clearColor];
             }
         }
@@ -67,7 +65,7 @@
     
     //Query for the day's levels
     PFQuery *queryForLevels = [PFQuery queryWithClassName:@"Schedule"];
-    [queryForLevels whereKey:@"dayNum" equalTo:@(indexPath.row+1)];
+    [queryForLevels whereKey:@"dayNum" equalTo:cellNum];
     [queryForLevels findObjectsInBackgroundWithBlock:^(NSArray * _Nullable objects, NSError * _Nullable error) {
         if (!error) {
             for (Schedule *object in objects) {
@@ -76,8 +74,7 @@
                 for (int i = 0; i < arrayOfLevels.count; i++) {
                     if (i == 0) {
                         levelsText = [levelsText stringByAppendingFormat:@"Level %@", arrayOfLevels[i]];
-                    }
-                    else {
+                    } else {
                         levelsText = [levelsText stringByAppendingFormat:@"\rLevel %@", arrayOfLevels[i]];
                     }
                 }

--- a/metau-capstone/ScheduleViewController.m
+++ b/metau-capstone/ScheduleViewController.m
@@ -56,6 +56,8 @@
 - (nonnull __kindof UICollectionViewCell *)collectionView:(nonnull UICollectionView *)collectionView cellForItemAtIndexPath:(nonnull NSIndexPath *)indexPath {
     ScheduleCell *cell = [self.scheduleCollection dequeueReusableCellWithReuseIdentifier:@"ScheduleCollectionCell" forIndexPath:indexPath];
     cell.dayNum.text = [NSString stringWithFormat:@"%ld", indexPath.row+1];
+    cell.layer.borderColor = [UIColor blueColor].CGColor;
+    cell.layer.borderWidth = 1;
     return cell;
 }
 

--- a/metau-capstone/ScheduleViewController.m
+++ b/metau-capstone/ScheduleViewController.m
@@ -13,8 +13,9 @@
 #import "Utilities.h"
 #import "ScheduleCell.h"
 
-@interface ScheduleViewController () <UICollectionViewDataSource>
+@interface ScheduleViewController () <UICollectionViewDataSource, UICollectionViewDelegate, UICollectionViewDelegateFlowLayout>
 @property (weak, nonatomic) IBOutlet UICollectionView *scheduleCollection;
+@property (weak, nonatomic) IBOutlet UICollectionViewFlowLayout *flowLayout;
 
 @end
 
@@ -23,8 +24,18 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
     self.scheduleCollection.dataSource = self;
-
+    self.scheduleCollection.delegate = self;
 }
+
+- (void)viewDidLayoutSubviews {
+   [super viewDidLayoutSubviews];
+
+    self.flowLayout.scrollDirection = UICollectionViewScrollDirectionHorizontal;
+    self.flowLayout.minimumLineSpacing = 0;
+    self.flowLayout.minimumInteritemSpacing = 0;
+    self.flowLayout.sectionInset = UIEdgeInsetsMake(0, 0, 0, 10);
+}
+
 
 - (IBAction)didTapLogout:(id)sender {
     SceneDelegate *sceneDelegate = (SceneDelegate *)self.view.window.windowScene.delegate;
@@ -44,12 +55,20 @@
 
 - (nonnull __kindof UICollectionViewCell *)collectionView:(nonnull UICollectionView *)collectionView cellForItemAtIndexPath:(nonnull NSIndexPath *)indexPath {
     ScheduleCell *cell = [self.scheduleCollection dequeueReusableCellWithReuseIdentifier:@"ScheduleCollectionCell" forIndexPath:indexPath];
-    cell.dayNum.text = [NSString stringWithFormat:@"%ld", indexPath.row];
+    cell.dayNum.text = [NSString stringWithFormat:@"%ld", indexPath.row+1];
     return cell;
 }
 
 - (NSInteger)collectionView:(nonnull UICollectionView *)collectionView numberOfItemsInSection:(NSInteger)section {
-    return 10;
+    return 64;
+}
+
+- (CGSize)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout *)collectionViewLayout sizeForItemAtIndexPath:(NSIndexPath *)indexPath{
+    int totalwidth = self.scheduleCollection.bounds.size.width;
+    int numberOfCellsPerRow = 4;
+    
+    int dimensions = (CGFloat)(totalwidth / (numberOfCellsPerRow + 1));
+    return CGSizeMake(dimensions, dimensions);
 }
 
 @end

--- a/metau-capstone/ScheduleViewController.m
+++ b/metau-capstone/ScheduleViewController.m
@@ -24,17 +24,10 @@
     [super viewDidLoad];
     self.scheduleCollection.dataSource = self;
     self.scheduleCollection.delegate = self;
+//    UILabel *fromLabel = [[UILabel alloc]initWithFrame:CGRectMake(10, 0, 100, 100)];
+//    fromLabel.text = @"hi";
+//    [self.scheduleCollection addSubview:fromLabel];
 }
-
-//- (void)viewDidLayoutSubviews {
-//   [super viewDidLayoutSubviews];
-//
-//    self.flowLayout.scrollDirection = UICollectionViewScrollDirectionHorizontal;
-//    self.flowLayout.minimumLineSpacing = 0;
-//    self.flowLayout.minimumInteritemSpacing = 0;
-//    self.flowLayout.sectionInset = UIEdgeInsetsMake(0, 0, 0, 10);
-//}
-
 
 - (IBAction)didTapLogout:(id)sender {
     SceneDelegate *sceneDelegate = (SceneDelegate *)self.view.window.windowScene.delegate;

--- a/metau-capstone/ScheduleViewController.m
+++ b/metau-capstone/ScheduleViewController.m
@@ -70,7 +70,7 @@
     int numberOfCellsPerRow = 4;
     
     int dimensions = (CGFloat)(totalwidth / (numberOfCellsPerRow + 1));
-    return CGSizeMake(dimensions, dimensions);
+    return CGSizeMake(dimensions, dimensions*1.2);
 }
 
 @end

--- a/metau-capstone/ScheduleViewController.m
+++ b/metau-capstone/ScheduleViewController.m
@@ -12,6 +12,7 @@
 #import "Schedule.h"
 #import "Utilities.h"
 #import "ScheduleCell.h"
+#import "Schedule.h"
 
 @interface ScheduleViewController () <UICollectionViewDataSource, UICollectionViewDelegate>
 @property (weak, nonatomic) IBOutlet UICollectionView *scheduleCollection;
@@ -50,6 +51,28 @@
     cell.dayNum.text = [NSString stringWithFormat:@"%ld", indexPath.row+1];
     cell.layer.borderColor = [UIColor blackColor].CGColor;
     cell.layer.borderWidth = 1;
+    
+    //Query for the day's levels
+    PFQuery *queryForLevels = [PFQuery queryWithClassName:@"Schedule"];
+    [queryForLevels whereKey:@"dayNum" equalTo:@(indexPath.row+1)];
+    [queryForLevels findObjectsInBackgroundWithBlock:^(NSArray * _Nullable objects, NSError * _Nullable error) {
+        if (!error) {
+            for (Schedule *object in objects) {
+                NSArray *arrayOfLevels = object.arrayOfLevels;
+                NSString *levelsText = @"";
+                for (int i = 0; i < arrayOfLevels.count; i++) {
+                    if (i == 0) {
+                        levelsText = [levelsText stringByAppendingFormat:@"Level %@", arrayOfLevels[i]];
+                    }
+                    else {
+                        levelsText = [levelsText stringByAppendingFormat:@"\rLevel %@", arrayOfLevels[i]];
+                    }
+                }
+                NSLog(@"%@", levelsText);
+                cell.levelsLabel.text = levelsText;
+            }
+        }
+    }];
     return cell;
 }
 

--- a/metau-capstone/ScheduleViewController.m
+++ b/metau-capstone/ScheduleViewController.m
@@ -56,7 +56,7 @@
 - (nonnull __kindof UICollectionViewCell *)collectionView:(nonnull UICollectionView *)collectionView cellForItemAtIndexPath:(nonnull NSIndexPath *)indexPath {
     ScheduleCell *cell = [self.scheduleCollection dequeueReusableCellWithReuseIdentifier:@"ScheduleCollectionCell" forIndexPath:indexPath];
     cell.dayNum.text = [NSString stringWithFormat:@"%ld", indexPath.row+1];
-    cell.layer.borderColor = [UIColor blueColor].CGColor;
+    cell.layer.borderColor = [UIColor blackColor].CGColor;
     cell.layer.borderWidth = 1;
     return cell;
 }

--- a/metau-capstone/ScheduleViewController.m
+++ b/metau-capstone/ScheduleViewController.m
@@ -13,9 +13,8 @@
 #import "Utilities.h"
 #import "ScheduleCell.h"
 
-@interface ScheduleViewController () <UICollectionViewDataSource, UICollectionViewDelegate, UICollectionViewDelegateFlowLayout>
+@interface ScheduleViewController () <UICollectionViewDataSource, UICollectionViewDelegate>
 @property (weak, nonatomic) IBOutlet UICollectionView *scheduleCollection;
-@property (weak, nonatomic) IBOutlet UICollectionViewFlowLayout *flowLayout;
 
 @end
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- displaying a grid view in the Schedule Screen
- the levels to review for each day are in each cell
- the current day is highlighted
- grid view is laid out so that there are 4 cells per row no matter the screen size

* **What is the current behavior?** (You can also link to an open issue here)
- the Schedule Screen was empty

* **What is the new behavior (if this is a feature change)?**
- Schedule Screen now has grid that shows entire spaced repetition study schedule

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Other information**:
- used UICollectionView
- query for the user's day
- query for the level numbers associated with each day

https://user-images.githubusercontent.com/44847817/179325604-0c741992-b0a2-4e8d-a25b-729c20495ad4.mov


