### PR TITLE
Shirley display only cards not reviewed

### DIFF
--- a/metau-capstone.xcworkspace/xcuserdata/shirleyzzhu.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/metau-capstone.xcworkspace/xcuserdata/shirleyzzhu.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -3,4 +3,22 @@
    uuid = "54AC4DCD-CC84-4485-B7FA-0BC1B9277227"
    type = "0"
    version = "2.0">
+   <Breakpoints>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "C61BA72F-8DAF-4E5F-ABB8-DA6DDF191C2F"
+            shouldBeEnabled = "Yes"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "metau-capstone/StudyViewController.m"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "106"
+            endingLineNumber = "106"
+            landmarkName = "-viewDidLoad"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
+   </Breakpoints>
 </Bucket>

--- a/metau-capstone.xcworkspace/xcuserdata/shirleyzzhu.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/metau-capstone.xcworkspace/xcuserdata/shirleyzzhu.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -3,22 +3,4 @@
    uuid = "54AC4DCD-CC84-4485-B7FA-0BC1B9277227"
    type = "0"
    version = "2.0">
-   <Breakpoints>
-      <BreakpointProxy
-         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
-         <BreakpointContent
-            uuid = "C61BA72F-8DAF-4E5F-ABB8-DA6DDF191C2F"
-            shouldBeEnabled = "Yes"
-            ignoreCount = "0"
-            continueAfterRunningActions = "No"
-            filePath = "metau-capstone/StudyViewController.m"
-            startingColumnNumber = "9223372036854775807"
-            endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "106"
-            endingLineNumber = "106"
-            landmarkName = "-viewDidLoad"
-            landmarkType = "7">
-         </BreakpointContent>
-      </BreakpointProxy>
-   </Breakpoints>
 </Bucket>

--- a/metau-capstone/API/APIManager.m
+++ b/metau-capstone/API/APIManager.m
@@ -35,7 +35,7 @@ static NSString * const baseURLString = @"https://sheets.googleapis.com";
 }
 
 - (void) getSheetsData: (void(^)(NSError *error))completion {
-    NSDictionary *parameters = @{@"key": self.APIkey,@"spreadsheetId": @"18hOQplD--E3VUtULuuzWqkW9oT5MPeLlgl3JjrAKH5E", @"range": @"Sheet1!A1:B1"};
+    NSDictionary *parameters = @{@"key": self.APIkey};
     AFHTTPSessionManager *manager = [[AFHTTPSessionManager alloc] initWithBaseURL:self.baseURL];
     manager.requestSerializer = [AFJSONRequestSerializer serializer];
     

--- a/metau-capstone/Flashcard.h
+++ b/metau-capstone/Flashcard.h
@@ -14,6 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong) NSString *backText;
 @property (nonatomic, strong) NSNumber *levelNum;
 @property (nonatomic, strong) NSString *userID;
+@property (nonatomic) BOOL toBeReviewed;
 
 + (void) createCard: ( NSString * _Nullable)frontText withBack: (NSString * _Nullable)backText withCompletion: (PFBooleanResultBlock  _Nullable)completion;
 

--- a/metau-capstone/Flashcard.m
+++ b/metau-capstone/Flashcard.m
@@ -13,6 +13,7 @@
 @dynamic backText;
 @dynamic levelNum;
 @dynamic userID;
+@dynamic toBeReviewed;
 
 + (nonnull NSString *)parseClassName {
     return @"Flashcard";
@@ -25,6 +26,7 @@
     newCard.backText = backText;
     newCard.levelNum = @(1);
     newCard.userID = [PFUser currentUser].objectId;
+    newCard.toBeReviewed = NO;
 
     [newCard saveInBackgroundWithBlock: completion];
 }

--- a/metau-capstone/StudyViewController.m
+++ b/metau-capstone/StudyViewController.m
@@ -188,16 +188,26 @@
         self.congratsLabel.hidden = YES;
         
         Flashcard *card = self.arrayOfCards[self.counter];
-        // BACK SIDE
-        // add text label to the flashcard
-        [self.backText setString:card.backText];
-        self.back.transform = CATransform3DMakeRotation(M_PI, 0, -1, 0);
-        [self.view.layer addSublayer:self.back];
         
-        // FRONT SIDE
-        // add text label to the flashcard
-        [self.frontText setString:card.frontText];
-        [self.view.layer addSublayer:self.front];
+        // PHASE II: Middle of studying cards
+        // Only display cards that have not been reviewed yet
+        if (!card.toBeReviewed) {
+            self.counter++;
+            [self loadFlashcard];
+        } else {
+            // BACK SIDE
+            // add text label to the flashcard
+            [self.backText setString:card.backText];
+            self.back.transform = CATransform3DMakeRotation(M_PI, 0, -1, 0);
+            [self.view.layer addSublayer:self.back];
+            
+            // FRONT SIDE
+            // add text label to the flashcard
+            [self.frontText setString:card.frontText];
+            [self.view.layer addSublayer:self.front];
+            
+            // Update card
+        }
     } else {
         NSLog(@"reached end of stack");
         [self endScreen];

--- a/metau-capstone/StudyViewController.m
+++ b/metau-capstone/StudyViewController.m
@@ -128,13 +128,7 @@
                 // PHASE III: Finished studying cards
             } else {
                 // PHASE IV: Waiting for new cards
-            }
-            
-            
-            if (![userObject[@"prevFinishedDate"] isEqual:[NSNull null]] && [todayDate isEqualToString:userObject[@"prevFinishedDate"]]) {
-                // show the end screen
                 [self endScreen];
-            } else {
             }
         } else {
             NSLog(@"no user");

--- a/metau-capstone/StudyViewController.m
+++ b/metau-capstone/StudyViewController.m
@@ -67,6 +67,9 @@
             } else if (![todayDate isEqualToString:userObject[@"prevFinishedDate"]] && [userObject[@"phaseNum"] isEqualToNumber:@(4)]) {
                 // PHASE I: Displaying new cards
                 userObject[@"phaseNum"] = @(2);
+                // Increment day counter for the user
+                [userObject incrementKey:@"userDay"];
+                
                 // Fetch today's cards:
                 // Fetch today's number for the current user
                 self.dayNum = userObject[@"userDay"];
@@ -208,9 +211,6 @@
                 // Update lastFinished date
                 userObject[@"prevFinishedDate"] = dateString;
                 [userObject saveInBackground];
-                
-                // Increment day counter for the user
-                [userObject incrementKey:@"userDay"];
             }
             else {
                 NSLog(@"no user");

--- a/metau-capstone/StudyViewController.m
+++ b/metau-capstone/StudyViewController.m
@@ -205,8 +205,6 @@
             // add text label to the flashcard
             [self.frontText setString:card.frontText];
             [self.view.layer addSublayer:self.front];
-            
-            // Update card
         }
     } else {
         NSLog(@"reached end of stack");
@@ -262,6 +260,10 @@
                                  block:^(PFObject *card, NSError *error) {
         [card incrementKey:@"levelNum"];
         [card saveInBackground];
+        
+        // Update card as no longer needing to be reviewed
+        card[@"toBeReviewed"] = @NO;
+        [card saveInBackground];
     }];
     
     self.counter++;
@@ -272,6 +274,9 @@
     // Reset level
     Flashcard *card = self.arrayOfCards[self.counter];
     [self resetCard:card];
+    // Update card as no longer needing to be reviewed
+    card[@"toBeReviewed"] = @NO;
+    [card saveInBackground];
     self.counter++;
     [self loadFlashcard];
 }

--- a/metau-capstone/StudyViewController.m
+++ b/metau-capstone/StudyViewController.m
@@ -21,7 +21,7 @@
 @property (nonatomic, strong) CABasicAnimation *rotateAnim;
 @property (nonatomic) CATransform3D horizontalFlip;
 @property (nonatomic) BOOL isFlipped;
-@property (nonatomic, strong) NSArray *arrayOfCards;
+@property (nonatomic, strong) NSArray<Flashcard *> *arrayOfCards;
 @property (nonatomic, assign) NSInteger counter;
 @property (weak, nonatomic) IBOutlet UIButton *leftButton;
 @property (weak, nonatomic) IBOutlet UIButton *rightButton;
@@ -98,11 +98,9 @@
                         PFQuery *query = [PFQuery queryWithClassName:@"Flashcard" predicate:predicate];
                         
                         // Fetch data for cards asynchronously
-                        [query findObjectsInBackgroundWithBlock:^(NSArray *cards, NSError *error) {
+                        [query findObjectsInBackgroundWithBlock:^(NSArray<Flashcard *> *cards, NSError *error) {
                             if (cards != nil) {
                                 self.arrayOfCards = cards;
-                                [userObject addObjectsFromArray:cards forKey:@"studyStack"];
-                                [userObject saveInBackground];
                                 NSLog(@"phase 1");
                                 self.counter = 0;
                                 [self loadFlashcard];
@@ -119,7 +117,6 @@
                 
             } else if (![todayDate isEqualToString:userObject[@"prevFinishedDate"]] && [userObject[@"phaseNum"] isEqualToNumber:@(2)]) {
                 // PHASE II: Middle of studying cards
-                
                 // PHASE III: Finished studying cards
             } else {
                 // PHASE IV: Waiting for new cards
@@ -254,7 +251,7 @@
 }
 
 - (IBAction)didTapLeft:(UIButton *)sender {
-    // Update level
+    // Reset level
     Flashcard *card = self.arrayOfCards[self.counter];
     [self resetCard:card];
     self.counter++;

--- a/metau-capstone/StudyViewController.m
+++ b/metau-capstone/StudyViewController.m
@@ -64,12 +64,12 @@
             // Check if first time user
             if ([userObject[@"prevFinishedDate"] isEqual:[NSNull null]]) {
                 [self endScreen];
-            } else if (![todayDate isEqualToString:userObject[@"prevFinishedDate"]] && [userObject[@"phaseNum"] isEqualToNumber:@(4)]) {
+            } else if (![todayDate isEqualToString:userObject[@"prevFinishedDate"]]) {
                 // PHASE I: Displaying new cards
-                userObject[@"phaseNum"] = @(2);
-                // Increment day counter for the user
-                [userObject incrementKey:@"userDay"];
-                
+                if ([userObject[@"phaseNum"] isEqualToNumber:@(4)]) {
+                    // Increment day counter for the user
+                    [userObject incrementKey:@"userDay"];
+                }
                 // Fetch today's cards:
                 // Fetch today's number for the current user
                 self.dayNum = userObject[@"userDay"];
@@ -103,6 +103,14 @@
                                 self.arrayOfCards = cards;
                                 NSLog(@"phase 1");
                                 self.counter = 0;
+                                if ([userObject[@"phaseNum"] isEqualToNumber:@(4)]) {
+                                    // Set toBeReviewed to be true for all card
+                                    for (Flashcard * cardToBeReviewed in self.arrayOfCards) {
+                                        cardToBeReviewed.toBeReviewed = YES;
+                                        [cardToBeReviewed saveInBackground];
+                                    }
+                                    userObject[@"phaseNum"] = @(2);
+                                }
                                 [self loadFlashcard];
                             } else {
                                 NSLog(@"%@", error.localizedDescription);

--- a/metau-capstone/StudyViewController.m
+++ b/metau-capstone/StudyViewController.m
@@ -101,7 +101,9 @@
                         [query findObjectsInBackgroundWithBlock:^(NSArray *cards, NSError *error) {
                             if (cards != nil) {
                                 self.arrayOfCards = cards;
-                                userObject[@"studyStack"] = cards;
+                                [userObject addObjectsFromArray:cards forKey:@"studyStack"];
+                                [userObject saveInBackground];
+                                NSLog(@"phase 1");
                                 self.counter = 0;
                                 [self loadFlashcard];
                             } else {

--- a/metau-capstone/StudyViewController.m
+++ b/metau-capstone/StudyViewController.m
@@ -67,19 +67,7 @@
             } else if (![todayDate isEqualToString:userObject[@"prevFinishedDate"]] && [userObject[@"phaseNum"] isEqualToNumber:@(4)]) {
                 // PHASE I: Displaying new cards
                 userObject[@"phaseNum"] = @(2);
-                
-            } else if (![todayDate isEqualToString:userObject[@"prevFinishedDate"]] && [userObject[@"phaseNum"] isEqualToNumber:@(2)]) {
-                // PHASE II: Middle of studying cards
-                
-                // PHASE III: Finished studying cards
-            } else {
-                // PHASE IV: Waiting for new cards
-            }
-            
-            if (![userObject[@"prevFinishedDate"] isEqual:[NSNull null]] && [todayDate isEqualToString:userObject[@"prevFinishedDate"]]) {
-                // show the end screen
-                [self endScreen];
-            } else {
+                // Fetch today's cards:
                 // Fetch today's number for the current user
                 self.dayNum = userObject[@"userDay"];
                 [userObject saveInBackground];
@@ -110,6 +98,7 @@
                         [query findObjectsInBackgroundWithBlock:^(NSArray *cards, NSError *error) {
                             if (cards != nil) {
                                 self.arrayOfCards = cards;
+                                userObject[@"studyStack"] = cards;
                                 self.counter = 0;
                                 [self loadFlashcard];
                             } else {
@@ -122,6 +111,20 @@
                     NSLog(@"Error: %@ %@", error, [error userInfo]);
                   }
                 }];
+                
+            } else if (![todayDate isEqualToString:userObject[@"prevFinishedDate"]] && [userObject[@"phaseNum"] isEqualToNumber:@(2)]) {
+                // PHASE II: Middle of studying cards
+                
+                // PHASE III: Finished studying cards
+            } else {
+                // PHASE IV: Waiting for new cards
+            }
+            
+            
+            if (![userObject[@"prevFinishedDate"] isEqual:[NSNull null]] && [todayDate isEqualToString:userObject[@"prevFinishedDate"]]) {
+                // show the end screen
+                [self endScreen];
+            } else {
             }
         } else {
             NSLog(@"no user");

--- a/metau-capstone/StudyViewController.m
+++ b/metau-capstone/StudyViewController.m
@@ -123,11 +123,9 @@
                   }
                 }];
                 
-            } else if (![todayDate isEqualToString:userObject[@"prevFinishedDate"]] && [userObject[@"phaseNum"] isEqualToNumber:@(2)]) {
-                // PHASE II: Middle of studying cards
-                // PHASE III: Finished studying cards
             } else {
                 // PHASE IV: Waiting for new cards
+                userObject[@"phaseNum"] = @(4);
                 [self endScreen];
             }
         } else {
@@ -201,6 +199,7 @@
             [self.view.layer addSublayer:self.front];
         }
     } else {
+        // PHASE III: Finished studying cards
         NSLog(@"reached end of stack");
         [self endScreen];
         

--- a/metau-capstone/StudyViewController.m
+++ b/metau-capstone/StudyViewController.m
@@ -201,6 +201,7 @@
     } else {
         // PHASE III: Finished studying cards
         NSLog(@"reached end of stack");
+        userObject[@"phaseNum"] = @(3);
         [self endScreen];
         
         NSLocale* currentLocale = [NSLocale currentLocale];

--- a/metau-capstone/StudyViewController.m
+++ b/metau-capstone/StudyViewController.m
@@ -102,14 +102,18 @@
                             if (cards != nil) {
                                 self.arrayOfCards = cards;
                                 NSLog(@"phase 1");
-                                self.counter = 0;
+                                self.counter  = 0;
                                 if ([userObject[@"phaseNum"] isEqualToNumber:@(4)]) {
                                     // Set toBeReviewed to be true for all card
                                     for (Flashcard * cardToBeReviewed in self.arrayOfCards) {
                                         cardToBeReviewed.toBeReviewed = YES;
                                         [cardToBeReviewed saveInBackground];
                                     }
-                                    userObject[@"phaseNum"] = @(2);
+                                    userObject[@"phaseNum"] = @2;
+                                    [userObject saveInBackground];
+                                    
+                                    userObject[@"startedReview"] = @YES;
+                                    [userObject saveInBackground];
                                 }
                                 [self loadFlashcard];
                             } else {
@@ -126,6 +130,7 @@
             } else {
                 // PHASE IV: Waiting for new cards
                 userObject[@"phaseNum"] = @(4);
+                [userObject saveInBackground];
                 [self endScreen];
             }
         } else {
@@ -201,7 +206,6 @@
     } else {
         // PHASE III: Finished studying cards
         NSLog(@"reached end of stack");
-        userObject[@"phaseNum"] = @(3);
         [self endScreen];
         
         NSLocale* currentLocale = [NSLocale currentLocale];
@@ -219,6 +223,9 @@
             if (userObject) {
                 // Update lastFinished date
                 userObject[@"prevFinishedDate"] = dateString;
+                [userObject saveInBackground];
+             
+                userObject[@"phaseNum"] = @(3);
                 [userObject saveInBackground];
             }
             else {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- fixes bug where cards already reviewed would show up again when user reopens app

* **What is the current behavior?** (You can also link to an open issue here)
- when user closes app before finishing a study stack, the app would show the study stack from be the beginning the next time they open the app

* **What is the new behavior (if this is a feature change)?**
- when user closes app before finishing a study stack, the app would reopen at the card they were last viewing

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


* **Other information**:
- video below shows the tests I ran on the code:


https://user-images.githubusercontent.com/44847817/180050204-ef91f2e0-06fa-4351-a5ed-ed0b257d64a9.mp4


- the user opens the app, new cards are displayed
- when user exits and re-enters, the app remembers which cards were already reviewed and only displays cards to be reviewed
- the day does not change yet - as seen on the Schedule screen
- I am pushing this code because it works but I plan to refactor and make the code more readable!