### PR TITLE
Shirley create flashcard in various user states

### DIFF
--- a/metau-capstone.xcworkspace/xcuserdata/shirleyzzhu.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/metau-capstone.xcworkspace/xcuserdata/shirleyzzhu.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -3,22 +3,4 @@
    uuid = "54AC4DCD-CC84-4485-B7FA-0BC1B9277227"
    type = "0"
    version = "2.0">
-   <Breakpoints>
-      <BreakpointProxy
-         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
-         <BreakpointContent
-            uuid = "74A123BC-8E67-4237-8620-0BBF1D8E7CCC"
-            shouldBeEnabled = "Yes"
-            ignoreCount = "0"
-            continueAfterRunningActions = "No"
-            filePath = "metau-capstone/View Controllers/StudyViewController.m"
-            startingColumnNumber = "9223372036854775807"
-            endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "83"
-            endingLineNumber = "83"
-            landmarkName = "-viewDidLoad"
-            landmarkType = "7">
-         </BreakpointContent>
-      </BreakpointProxy>
-   </Breakpoints>
 </Bucket>

--- a/metau-capstone.xcworkspace/xcuserdata/shirleyzzhu.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/metau-capstone.xcworkspace/xcuserdata/shirleyzzhu.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -7,22 +7,6 @@
       <BreakpointProxy
          BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
          <BreakpointContent
-            uuid = "627AB966-6560-4006-85C1-6B57633F0F28"
-            shouldBeEnabled = "Yes"
-            ignoreCount = "0"
-            continueAfterRunningActions = "No"
-            filePath = "metau-capstone/View Controllers/StudyViewController.m"
-            startingColumnNumber = "9223372036854775807"
-            endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "185"
-            endingLineNumber = "185"
-            landmarkName = "-loadFlashcard"
-            landmarkType = "7">
-         </BreakpointContent>
-      </BreakpointProxy>
-      <BreakpointProxy
-         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
-         <BreakpointContent
             uuid = "74A123BC-8E67-4237-8620-0BBF1D8E7CCC"
             shouldBeEnabled = "Yes"
             ignoreCount = "0"

--- a/metau-capstone.xcworkspace/xcuserdata/shirleyzzhu.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/metau-capstone.xcworkspace/xcuserdata/shirleyzzhu.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -3,4 +3,38 @@
    uuid = "54AC4DCD-CC84-4485-B7FA-0BC1B9277227"
    type = "0"
    version = "2.0">
+   <Breakpoints>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "627AB966-6560-4006-85C1-6B57633F0F28"
+            shouldBeEnabled = "Yes"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "metau-capstone/View Controllers/StudyViewController.m"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "185"
+            endingLineNumber = "185"
+            landmarkName = "-loadFlashcard"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "74A123BC-8E67-4237-8620-0BBF1D8E7CCC"
+            shouldBeEnabled = "Yes"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "metau-capstone/View Controllers/StudyViewController.m"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "83"
+            endingLineNumber = "83"
+            landmarkName = "-viewDidLoad"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
+   </Breakpoints>
 </Bucket>

--- a/metau-capstone/View Controllers/StudyViewController.m
+++ b/metau-capstone/View Controllers/StudyViewController.m
@@ -323,7 +323,6 @@
 }
 
 - (void) viewWillAppear:(BOOL)animated {
-    NSLog(@"howdy");
     PFUser *const user = [PFUser currentUser];
     PFQuery *query = [PFUser query];
     [query getObjectInBackgroundWithId:user.objectId
@@ -334,9 +333,11 @@
           [queryForCards findObjectsInBackgroundWithBlock:^(NSArray * _Nullable cards, NSError * _Nullable error) {
               self.arrayOfCards = cards;
               self.counter = 0;
+              self.prevFinishedDate = userObject[@"prevFinishedDate"];
               if ([cards count] == 0) {
                   [self startScreen];
-              } else {
+              } else if ([self isFirstTimeUser]) {
+                  NSLog(@"howdy first time user");
                   if ([userObject[@"didStartReview"] isEqual:@NO]) {
                       // Set toBeReviewed to be true for all card
                       for (Flashcard * cardToBeReviewed in self.arrayOfCards) {

--- a/metau-capstone/View Controllers/StudyViewController.m
+++ b/metau-capstone/View Controllers/StudyViewController.m
@@ -104,8 +104,6 @@
                 
             } else {
                 // Waiting for new cards
-                userObject[@"didStartReview"] = @NO;
-                [userObject saveInBackground];
                 [self endScreen];
             }
         } else {
@@ -213,6 +211,9 @@
             if (userObject) {
                 // Update lastFinished date
                 userObject[@"prevFinishedDate"] = dateString;
+                [userObject saveInBackground];
+                
+                userObject[@"didStartReview"] = @NO;
                 [userObject saveInBackground];
             } else {
                 NSLog(@"no user");

--- a/metau-capstone/View Controllers/StudyViewController.m
+++ b/metau-capstone/View Controllers/StudyViewController.m
@@ -115,12 +115,25 @@
     
 }
 
+- (BOOL) isNewDay {
+    return ![[self todayDate] isEqualToString:self.prevFinishedDate];
+}
+
 - (BOOL) isFirstTimeUser {
     return self.prevFinishedDate == nil;
 }
 
-- (BOOL) isNewDay {
-    return ![[self todayDate] isEqualToString:self.prevFinishedDate];
+- (NSString *) stringWithLevels: (NSArray *) arrayOfLevels{
+    NSString *constraintForCards = @"(userID = %@) AND ";
+    for (int i = 0; i < arrayOfLevels.count; i++) {
+        if (i == 0) {
+            constraintForCards = [constraintForCards stringByAppendingFormat:@"(levelNum = %@", arrayOfLevels[i]];
+        } else {
+            constraintForCards = [constraintForCards stringByAppendingFormat:@" OR levelNum = %@", arrayOfLevels[i]];
+        }
+    }
+    constraintForCards = [constraintForCards stringByAppendingString: @")"];
+    return constraintForCards;
 }
 
 - (void) createCardBothSides {
@@ -162,19 +175,6 @@
     NSDateFormatter *dateFormatter=[[NSDateFormatter alloc] init];
     [dateFormatter setDateFormat:@"yyyy-MM-dd"];
     return [dateFormatter stringFromDate:currentDate];
-}
-
-- (NSString *) stringWithLevels: (NSArray *) arrayOfLevels{
-    NSString *constraintForCards = @"(userID = %@) AND ";
-    for (int i = 0; i < arrayOfLevels.count; i++) {
-        if (i == 0) {
-            constraintForCards = [constraintForCards stringByAppendingFormat:@"(levelNum = %@", arrayOfLevels[i]];
-        } else {
-            constraintForCards = [constraintForCards stringByAppendingFormat:@" OR levelNum = %@", arrayOfLevels[i]];
-        }
-    }
-    constraintForCards = [constraintForCards stringByAppendingString: @")"];
-    return constraintForCards;
 }
 
 - (void) loadFlashcard {
@@ -321,4 +321,39 @@
     [utility logout: sceneDelegate];
 }
 
+- (void) viewWillAppear:(BOOL)animated {
+    NSLog(@"howdy");
+    PFUser *const user = [PFUser currentUser];
+    PFQuery *query = [PFUser query];
+    [query getObjectInBackgroundWithId:user.objectId
+                                  block:^(PFObject *userObject, NSError *error) {
+      if (!error) {
+          PFQuery *queryForCards = [PFQuery queryWithClassName:@"Flashcard"];
+          [queryForCards whereKey:@"userID" equalTo:userObject.objectId];
+          [queryForCards findObjectsInBackgroundWithBlock:^(NSArray * _Nullable cards, NSError * _Nullable error) {
+              self.arrayOfCards = cards;
+              self.counter = 0;
+              if ([cards count] == 0) {
+                  [self startScreen];
+              } else {
+                  if ([userObject[@"didStartReview"] isEqual:@NO]) {
+                      // Set toBeReviewed to be true for all card
+                      for (Flashcard * cardToBeReviewed in self.arrayOfCards) {
+                          cardToBeReviewed.toBeReviewed = YES;
+                          [cardToBeReviewed saveInBackground];
+                      }
+                      userObject[@"didStartReview"] = @YES;
+                      [userObject saveInBackground];
+                  }
+                  // Display flashcards
+                  [self loadFlashcard];
+              }
+          }];
+      } else {
+        // Log details of the failure
+        NSLog(@"Error: %@ %@", error, [error userInfo]);
+      }
+    }];
+}
+            
 @end


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- taking care of what happens when the user creates a card in the middle of studying

* **What is the current behavior?** (You can also link to an open issue here)
- when a user creates a card, the new card is not shown until the next day
- when a new user creates a card, the new card is not shown at all

* **What is the new behavior (if this is a feature change)?**
- when a new user creates a card, the new card is shown

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
- no

* **Other information**:
I learned about the difference between viewDidLoad and viewWillAppear. Since I populate the arrayOfCards in viewDidLoad, the array of flashcards for returning users is determined once and will not change after they add new cards in the middle of studying. I added code to viewWillAppear to handle a new user creating cards because I do want the flashcards to show for new users.

Video demo of new user adding cards and the cards appearing:

https://user-images.githubusercontent.com/44847817/180837664-ec6f1f39-b3fd-4697-a59e-786e40d4d4b4.mp4


