### PR TITLE
Shirley progress circle backend

### DIFF
--- a/metau-capstone/Base.lproj/Main.storyboard
+++ b/metau-capstone/Base.lproj/Main.storyboard
@@ -151,10 +151,13 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pKI-2t-R8V" customClass="CircleProgressBar">
-                                <rect key="frame" x="127" y="593" width="160" height="160"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pKI-2t-R8V" customClass="CircleProgressBar">
+                                <rect key="frame" x="112" y="579" width="190" height="190"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="190" id="CGj-yr-ykJ"/>
+                                    <constraint firstAttribute="width" constant="190" id="y7q-Tn-Ecz"/>
+                                </constraints>
                             </view>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="xIU-OP-FRg"/>
@@ -165,6 +168,8 @@
                             <constraint firstItem="nQn-4x-lhI" firstAttribute="width" secondItem="ss0-QC-Ui1" secondAttribute="width" id="2QY-wl-k3r"/>
                             <constraint firstItem="nQn-4x-lhI" firstAttribute="height" secondItem="ss0-QC-Ui1" secondAttribute="height" id="Mla-5W-Ug2"/>
                             <constraint firstItem="xIU-OP-FRg" firstAttribute="trailing" secondItem="nQn-4x-lhI" secondAttribute="trailing" constant="78" id="QXm-S8-dzu"/>
+                            <constraint firstItem="xIU-OP-FRg" firstAttribute="bottom" secondItem="pKI-2t-R8V" secondAttribute="bottom" constant="44" id="VG1-UZ-hUt"/>
+                            <constraint firstItem="pKI-2t-R8V" firstAttribute="centerX" secondItem="xIU-OP-FRg" secondAttribute="centerX" id="n1p-WG-ejV"/>
                             <constraint firstItem="ss0-QC-Ui1" firstAttribute="leading" secondItem="xIU-OP-FRg" secondAttribute="leading" constant="79" id="qJM-as-m4o"/>
                             <constraint firstItem="xIU-OP-FRg" firstAttribute="bottom" secondItem="ss0-QC-Ui1" secondAttribute="bottom" constant="250" id="y8z-Hg-hDG"/>
                         </constraints>

--- a/metau-capstone/View Controllers/LoginViewController.m
+++ b/metau-capstone/View Controllers/LoginViewController.m
@@ -62,6 +62,7 @@
     newUser[@"userDay"] = @(1);
     newUser[@"didStartReview"] = @NO;
     newUser[@"prevFinishedDate"] = [NSNull null];
+    newUser[@"percentFinished"] = @(0);
     
     // call sign up function on the object
     [newUser signUpInBackgroundWithBlock:^(BOOL succeeded, NSError * error) {

--- a/metau-capstone/View Controllers/StudyViewController.m
+++ b/metau-capstone/View Controllers/StudyViewController.m
@@ -46,6 +46,9 @@
     
     self.prevFinishedDate = user[@"prevFinishedDate"];
     
+    self.percentFinished = [user[@"percentFinished"] doubleValue];
+    [self.circleProgressBar setProgress:self.percentFinished animated:YES];
+    
     if ([self isFirstTimeUser] || [self isNewDay]) {
         // Check user has started reviewing for the day
         if (![self isFirstTimeUser] && [user[@"didStartReview"] isEqual:@NO]) {
@@ -75,7 +78,6 @@
                     [query findObjectsInBackgroundWithBlock:^(NSArray<Flashcard *> *cards, NSError *error) {
                         if (cards != nil) {
                             self.arrayOfCards = cards;
-                            self.percentFinished = 0.0;
                             self.counter = 0;
                             if ([cards count] == 0) {
                                 [self startScreen];
@@ -303,7 +305,11 @@
 - (void) incrementCircleProgress {
     self.percentFinished += [self progressPercentIncrement];
     [self.circleProgressBar setProgress:self.percentFinished animated:YES];
+    PFUser *const user = [PFUser currentUser];
+    user[@"percentFinished"] = @(self.percentFinished);
+    [user saveInBackground];
 }
+
 /*
  #pragma mark - Navigation
  


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- fixing bug where percent displayed starts at 0% every time user opens the app

**What is the current behavior?** (You can also link to an open issue here)
- when the user closes the app while studying, the progress percent is not kept track of

**What is the new behavior (if this is a feature change)?**
- when the user closes the app while studying, the progress percent is kept track of
- when the user reopens the app, the correct progress percent will be displayed

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
- no

**Other information**:

https://user-images.githubusercontent.com/44847817/181164948-1858c746-18b4-49eb-8b7b-ea2ed7c1ee4a.mp4


